### PR TITLE
使用EPPlus代替EPPlus.Core

### DIFF
--- a/src/Magicodes.ExporterAndImporter.Excel/Magicodes.ExporterAndImporter.Excel.csproj
+++ b/src/Magicodes.ExporterAndImporter.Excel/Magicodes.ExporterAndImporter.Excel.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!--注意不能使用1.5.4的版本，在Docker环境下存在Gdip异常-->
-    <PackageReference Include="EPPlus.Core" Version="1.5.4" />
+    <PackageReference Include="EPPlus" Version="4.5.3.2" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
EPPlus支持.net core 后,EPPlus.Core已经不维护了,使用EPPlus替换后可以通过单元测试